### PR TITLE
docs(changelog): Removed duplicate 6.6.0 entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,6 @@
 ## 6.6.0
 * bugfix: enable run of non-bdd projects, ([#166](https://github.com/vitalets/playwright-bdd/issues/166))
 
-## 6.6.0
-* bugfix: enable run of non-bdd projects, ([#166](https://github.com/vitalets/playwright-bdd/issues/166))
-
 ## 6.5.2
 * bugfix: createBdd returns Cucumber-Style Typing when using Playwright-Style, ([#163](https://github.com/vitalets/playwright-bdd/issues/163))
 


### PR DESCRIPTION
Hi, there is a duplicate entry in the changelogs, so here is a PR to fix it.
![image](https://github.com/user-attachments/assets/7a305343-9845-4d11-9089-b354829ab455)

Thanks for the awesome work