### PR TITLE
use named export from @cucumber/html-formatter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@cucumber/gherkin": "28.0.0",
         "@cucumber/gherkin-streams": "5.0.1",
         "@cucumber/gherkin-utils": "9.0.0",
-        "@cucumber/html-formatter": "21.4.0",
+        "@cucumber/html-formatter": "21.7.0",
         "@cucumber/messages": "25.0.1",
         "@cucumber/tag-expressions": "6.1.0",
         "cli-table3": "0.6.5",
@@ -1017,9 +1017,10 @@
       "deprecated": "This version has a critical bug in fallback handling. Please upgrade to reflect-metadata@0.2.2 or newer."
     },
     "node_modules/@cucumber/html-formatter": {
-      "version": "21.4.0",
-      "resolved": "https://registry.npmjs.org/@cucumber/html-formatter/-/html-formatter-21.4.0.tgz",
-      "integrity": "sha512-Vg8FpBFWUl6tXWdh+4Hk4Pf8r7KJhkNxMRULCLtjrIgM3cjap/jbc0hxiX6ta7a54CpUPAmmUOURTxuqsm64lQ==",
+      "version": "21.7.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/html-formatter/-/html-formatter-21.7.0.tgz",
+      "integrity": "sha512-bv211aY8mErp6CdmhN426E+7KIsVIES4fGx5ASMlUzYWiMus6NhSdI9UL3Vswx8JXJMgySeIcJJKfznREUFLNA==",
+      "license": "MIT",
       "peerDependencies": {
         "@cucumber/messages": ">=18"
       }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@cucumber/gherkin": "28.0.0",
     "@cucumber/gherkin-streams": "5.0.1",
     "@cucumber/gherkin-utils": "9.0.0",
-    "@cucumber/html-formatter": "21.4.0",
+    "@cucumber/html-formatter": "21.7.0",
     "@cucumber/messages": "25.0.1",
     "@cucumber/tag-expressions": "6.1.0",
     "cli-table3": "0.6.5",

--- a/src/reporter/cucumber/html.ts
+++ b/src/reporter/cucumber/html.ts
@@ -5,7 +5,7 @@
  * See: https://github.com/cucumber/react-components
  */
 import { finished } from 'node:stream/promises';
-import CucumberHtmlStream from '@cucumber/html-formatter';
+import { CucumberHtmlStream } from '@cucumber/html-formatter';
 import { resolvePackageRoot } from '../../utils';
 import path from 'node:path';
 import BaseReporter, { InternalOptions } from './base';


### PR DESCRIPTION
This PR upgrades the `@cucumber/html-formatter` dependency to the latest version, and changes the import of `CucumberHtmlStream` to be from the new named export, rather than the default export. This is to free up the default export, because in future we will export a full formatter plugin from this package, and the convention with those will be using the default export. See https://github.com/cucumber/html-formatter/pull/320 and https://github.com/cucumber/cucumber-js/discussions/2091#discussioncomment-10228427.