### PR TITLE
doc: Add step to install browsers to getting started documentation

### DIFF
--- a/docs/getting-started/write-first-test.md
+++ b/docs/getting-started/write-first-test.md
@@ -66,17 +66,17 @@ Then('I see in title {string}', async ({ page }, keyword) => {
 Generate and run the tests:
 
 ```
-npx bddgen && npx playwright test
+npx bddgen && npx playwright install && npx playwright test
 ```
 
 Command for **Yarn**
 ```
-yarn bddgen && yarn playwright test
+yarn bddgen && yarn playwright install && yarn playwright test
 ```
 
 Command for **pnpm**:
 ```
-pnpm bddgen && pnpm playwright test
+pnpm bddgen && pnpm playwright install && pnpm playwright test
 ```
 
 Output:


### PR DESCRIPTION
Was following the "Getting Started" documentation up to [here](https://vitalets.github.io/playwright-bdd/#/getting-started/write-first-test?id=step-4-run-tests), and noticed that when I ran `npx bddgen && npx playwright test`, I got this error:

<img width="1111" height="363" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/967dae3b-2cd5-4491-8183-965437d135c4" />

The error message is straighforward, but I think this should be included in the documentation as a step to do before running `npx playwright test`