### PR TITLE
fix: match tests by title instead of line number in reporter

### DIFF
--- a/src/bddData/renderer.ts
+++ b/src/bddData/renderer.ts
@@ -51,6 +51,7 @@ export class BddDataRenderer {
     return {
       pwTestLine: this.sourceMapper.getPwTestLine(test.pickle),
       pickleLine: test.pickle.location.line,
+      testTitle: test.testTitle, // store test title for reliable matching in reporter
       skipped: test.skipped || undefined,
       timeout: test.ownTimeout,
       slow: test.slow || undefined,

--- a/src/bddData/types.ts
+++ b/src/bddData/types.ts
@@ -17,6 +17,7 @@ export type BddFileData = BddTestData[];
 export type BddTestData = {
   pwTestLine: number;
   pickleLine: number;
+  testTitle: string; // test title for reliable matching in reporter
   tags: string[];
   skipped?: boolean;
   timeout?: number;

--- a/src/reporter/cucumber/messagesBuilder/index.ts
+++ b/src/reporter/cucumber/messagesBuilder/index.ts
@@ -63,11 +63,17 @@ export class MessagesBuilder {
     if (!bddConfig) return;
 
     const { bddData, featureUri } = this.testFiles.getBddData(test.location.file);
-    // todo: move these line somewhere else
-    const bddTestData = bddData.find((data) => data.pwTestLine === test.location.line);
+    // Match by test title (reliable) with fallback to line number (legacy).
+    // Note: Playwright's test.location.line in reporters may point to describe block
+    // instead of actual test line, so we prefer matching by title.
+    const bddTestData =
+      bddData.find((data) => data.testTitle === test.title) ||
+      bddData.find((data) => data.pwTestLine === test.location.line);
     if (!bddTestData) {
       const filePath = relativeToCwd(test.location.file);
-      throw new Error(`Cannot find bddTestData for ${filePath}:${test.location.line}`);
+      throw new Error(
+        `Cannot find bddTestData for ${filePath}:${test.location.line} (title: ${test.title})`,
+      );
     }
 
     // Important to create TestCaseRun in this method (not later),


### PR DESCRIPTION
## Summary

Playwright's `test.location.line` in reporters may point to the describe block instead of the actual test line. This causes "Cannot find bddTestData" errors in the cucumber reporter because the line number doesn't match the `pwTestLine` in bddFileData.

### Root Cause

When a test is inside a `test.describe()` block, Playwright's reporter API reports `test.location.line` as the line where the describe block starts, not where the actual `test()` call is. For example:

```javascript
// Line 4: test.describe('API Check', () => {   ← Playwright reports this line
// Line 5: 
// Line 6:   test('My Test', async () => {      ← bddFileData has this line
```

The cucumber reporter tries to find `bddTestData` where `data.pwTestLine === test.location.line`, but this fails because `4 !== 6`.

### Solution

This fix adds the test title to `bddFileData` and uses it as the primary matching criterion, with line number as a fallback for backward compatibility:

1. Add `testTitle` field to `BddTestData` type
2. Store test title in `BddDataRenderer` during generation
3. Match by test title first, then by line number in `MessagesBuilder`

### Changes

- `src/bddData/types.ts` - Add `testTitle: string` field
- `src/bddData/renderer.ts` - Store `test.testTitle` in bddFileData
- `src/reporter/cucumber/messagesBuilder/index.ts` - Match by title first, line number as fallback

### Testing

Tested locally with 49 BDD tests - all pass without reporter errors.