### PR TITLE
Fix bddgen memory usage: add `--workers` option and optimize pickle lookup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "cli-table3": "0.6.5",
         "commander": "^13.1.0",
         "mime-types": "^3.0.2",
+        "p-map": "^7.0.4",
         "tinyglobby": "0.2.15",
         "xmlbuilder": "15.1.1"
       },
@@ -7699,6 +7700,18 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-map": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
+      "integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "cli-table3": "0.6.5",
     "commander": "^13.1.0",
     "mime-types": "^3.0.2",
+    "p-map": "^7.0.4",
     "tinyglobby": "0.2.15",
     "xmlbuilder": "15.1.1"
   },

--- a/src/cli/commands/test.ts
+++ b/src/cli/commands/test.ts
@@ -1,5 +1,6 @@
 import { Worker } from 'node:worker_threads';
 import { once } from 'node:events';
+import os from 'node:os';
 import path from 'node:path';
 import { Command } from 'commander';
 import { TestFilesGenerator } from '../../generate';
@@ -14,10 +15,12 @@ import { showWarnings } from '../../config/warnings';
 import { Logger } from '../../utils/logger';
 
 const GEN_WORKER_PATH = path.resolve(__dirname, '..', 'worker.js');
+const DEFAULT_WORKERS = Math.max(1, Math.floor((os.availableParallelism?.() ?? os.cpus().length) / 2));
 
 type TestCommandOptions = ConfigOption & {
   tags?: string;
   verbose?: string;
+  workers?: string;
 };
 
 export const testCommand = new Command('test')
@@ -25,6 +28,7 @@ export const testCommand = new Command('test')
   .configureHelp({ showGlobalOptions: true })
   .option('--tags <expression>', `Tags expression to filter scenarios for generation`)
   .option('--verbose', `Verbose mode (default: ${Boolean(defaults.verbose)})`)
+  .option('--workers <number>', `Max parallel worker threads for generation (default: ${DEFAULT_WORKERS})`)
   .action(async () => {
     const opts = testCommand.optsWithGlobals<TestCommandOptions>();
     setBddGenPhase();
@@ -32,8 +36,9 @@ export const testCommand = new Command('test')
     const configs = readConfigsFromEnv();
     mergeCliOptions(configs, opts);
     const isVerbose = hasVerboseFlag(configs);
+    const workers = parseWorkers(opts.workers);
 
-    await generateFilesForConfigs(configs);
+    await generateFilesForConfigs(configs, workers);
 
     if (isVerbose) printDone();
   });
@@ -58,14 +63,24 @@ export function assertConfigsCount(configs: unknown[]) {
   }
 }
 
-async function generateFilesForConfigs(configs: BDDConfig[]) {
+async function generateFilesForConfigs(configs: BDDConfig[], concurrency: number) {
   // run first config in main thread and other in workers (to have fresh require cache)
   // See: https://github.com/vitalets/playwright-bdd/issues/32
-  const tasks = configs.map((config, index) => {
-    return index === 0 ? new TestFilesGenerator(config).generate() : runInWorker(config);
-  });
+  const { default: pMap } = await import('p-map');
+  const [firstConfig, ...restConfigs] = configs;
+  await new TestFilesGenerator(firstConfig!).generate();
+  if (restConfigs.length > 0) {
+    await pMap(restConfigs, (config) => runInWorker(config), { concurrency });
+  }
+}
 
-  return Promise.all(tasks);
+function parseWorkers(value: string | undefined): number {
+  if (value === undefined) return DEFAULT_WORKERS;
+  const n = parseInt(value, 10);
+  if (isNaN(n) || n < 1) {
+    exit(`Invalid --workers value: "${value}". Must be a positive integer.`);
+  }
+  return n;
 }
 
 async function runInWorker(config: BDDConfig) {

--- a/src/gherkin/featuresLoader.ts
+++ b/src/gherkin/featuresLoader.ts
@@ -12,7 +12,6 @@ import { Query as GherkinQuery } from '@cucumber/gherkin-utils';
 import {
   ParseError,
   Pickle,
-  GherkinDocument,
   IdGenerator,
   SourceMediaType,
 } from '@cucumber/messages';

--- a/src/gherkin/featuresLoader.ts
+++ b/src/gherkin/featuresLoader.ts
@@ -56,8 +56,21 @@ export class FeaturesLoader {
   }
 
   getDocumentsWithPickles(): GherkinDocumentWithPickles[] {
+    const picklesByUri = new Map<string, Pickle[]>();
+    for (const pickle of this.gherkinQuery.getPickles()) {
+      const uri = pickle.uri!;
+      let arr = picklesByUri.get(uri);
+      if (!arr) {
+        arr = [];
+        picklesByUri.set(uri, arr);
+      }
+      arr.push(pickle);
+    }
+
     return this.gherkinQuery.getGherkinDocuments().map((gherkinDocument) => {
-      const pickles = this.getDocumentPickles(gherkinDocument);
+      const pickles = (picklesByUri.get(gherkinDocument.uri!) ?? []).map((pickle) =>
+        this.getPickleWithLocation(pickle),
+      );
       return { ...gherkinDocument, pickles };
     });
   }
@@ -80,13 +93,6 @@ export class FeaturesLoader {
         this.parseErrors.push(envelope.parseError);
       }
     });
-  }
-
-  private getDocumentPickles(gherkinDocument: GherkinDocument) {
-    return this.gherkinQuery
-      .getPickles()
-      .filter((pickle) => gherkinDocument.uri === pickle.uri)
-      .map((pickle) => this.getPickleWithLocation(pickle));
   }
 
   private getPickleWithLocation(pickle: Pickle) {

--- a/test/cli-option-workers/package.json
+++ b/test/cli-option-workers/package.json
@@ -1,0 +1,3 @@
+{
+  "description": "This file is required for Playwright to consider this dir as a <package-json dir>. It ensures to load 'playwright-bdd' from './test/node_modules/playwright-bdd' and output './test-results' here to avoid conflicts."
+}

--- a/test/cli-option-workers/playwright.config.ts
+++ b/test/cli-option-workers/playwright.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from '@playwright/test';
+import { defineBddProject } from 'playwright-bdd';
+
+export default defineConfig({
+  projects: [
+    defineBddProject({
+      name: 'project1',
+      featuresRoot: 'project1',
+    }),
+    defineBddProject({
+      name: 'project2',
+      featuresRoot: 'project2',
+    }),
+  ],
+});

--- a/test/cli-option-workers/project1/sample.feature
+++ b/test/cli-option-workers/project1/sample.feature
@@ -1,0 +1,4 @@
+Feature: sample Feature
+
+  Scenario: scenario 1
+    Given state 1

--- a/test/cli-option-workers/project1/steps.ts
+++ b/test/cli-option-workers/project1/steps.ts
@@ -1,0 +1,7 @@
+import { createBdd } from 'playwright-bdd';
+
+const { Given } = createBdd();
+
+Given('state {int}', async () => {
+  // noop
+});

--- a/test/cli-option-workers/project2/sample.feature
+++ b/test/cli-option-workers/project2/sample.feature
@@ -1,0 +1,4 @@
+Feature: sample Feature
+
+  Scenario: scenario 1
+    Given state 1

--- a/test/cli-option-workers/project2/steps.ts
+++ b/test/cli-option-workers/project2/steps.ts
@@ -1,0 +1,7 @@
+import { createBdd } from 'playwright-bdd';
+
+const { Given } = createBdd();
+
+Given('state {int}', async () => {
+  // noop
+});

--- a/test/cli-option-workers/test.mjs
+++ b/test/cli-option-workers/test.mjs
@@ -1,0 +1,43 @@
+import {
+  test,
+  TestDir,
+  execPlaywrightTest,
+  execPlaywrightTestWithError,
+  BDDGEN_CMD,
+} from '../_helpers/index.mjs';
+
+const testDir = new TestDir(import.meta);
+
+test(`${testDir.name} (--workers 1)`, () => {
+  execPlaywrightTest(testDir.name, { cmd: `${BDDGEN_CMD} --workers 1` });
+  testDir.expectFileExists('.features-gen/project1/sample.feature.spec.js');
+  testDir.expectFileExists('.features-gen/project2/sample.feature.spec.js');
+});
+
+test(`${testDir.name} (--workers 2)`, () => {
+  execPlaywrightTest(testDir.name, { cmd: `${BDDGEN_CMD} --workers 2` });
+  testDir.expectFileExists('.features-gen/project1/sample.feature.spec.js');
+  testDir.expectFileExists('.features-gen/project2/sample.feature.spec.js');
+});
+
+test(`${testDir.name} (default workers)`, () => {
+  execPlaywrightTest(testDir.name, { cmd: BDDGEN_CMD });
+  testDir.expectFileExists('.features-gen/project1/sample.feature.spec.js');
+  testDir.expectFileExists('.features-gen/project2/sample.feature.spec.js');
+});
+
+test(`${testDir.name} (--workers 0 errors)`, () => {
+  execPlaywrightTestWithError(
+    testDir.name,
+    'Invalid --workers value: "0". Must be a positive integer.',
+    { cmd: `${BDDGEN_CMD} --workers 0` },
+  );
+});
+
+test(`${testDir.name} (--workers abc errors)`, () => {
+  execPlaywrightTestWithError(
+    testDir.name,
+    'Invalid --workers value: "abc". Must be a positive integer.',
+    { cmd: `${BDDGEN_CMD} --workers abc` },
+  );
+});


### PR DESCRIPTION
When you have multiple `defineBddConfig` projects, `bddgen` spawns all of them concurrently via `Promise.all`, each in its own worker thread. With enough projects this causes out-of-memory crashes in memory-constrained CI environments. 

This PR adds a `--workers` option to cap concurrency (defaults to `cpus/2`) using `p-map` and fixes an O(N*M) pickle lookup in `FeaturesLoader` that was filtering all pickles for every document instead of indexing them by URI upfront.