### PR TITLE
[Feature]: Expose doc string media types to step definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,8 @@
 * chore: replace `fast-glob` with `tinyglobby` ([#366](https://github.com/vitalets/playwright-bdd/pull/366))
 * perf: limit `bddgen` worker concurrency to `cpus/2` to prevent OOM in memory-constrained CI environments ([#376](https://github.com/vitalets/playwright-bdd/pull/376))
 * perf: optimize pickle lookup in `FeaturesLoader` from O(N×M) to O(N+M) using URI-indexed map ([#376](https://github.com/vitalets/playwright-bdd/pull/376))
-* fix: correct handling of retries in the Cucumber HTML reporter 
+* fix: correct handling of retries in the Cucumber HTML reporter
+* feat: doc string media types added to `$step` fixture as `docStringType` ([#380](https://github.com/vitalets/playwright-bdd/issues/380))
 
 ## [8.5.0] - 2026-03-13
 * docs: document `defineParameterType` helper

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -29,6 +29,7 @@
   - [Keywords matching](writing-steps/keywords-matching.md)
   - [Re-using step function](writing-steps/reusing-step-fn.md)
   - [Data tables](writing-steps/data-tables.md)
+  - [Doc strings](writing-steps/doc-strings.md)
   - [Snippets](writing-steps/snippets.md)
 
 * [**Reporters**](reporters/index.md)

--- a/docs/writing-steps/doc-strings.md
+++ b/docs/writing-steps/doc-strings.md
@@ -1,0 +1,65 @@
+# Using Doc Strings
+Playwright-BDD supports [Gherkin "doc strings"](https://cucumber.io/docs/gherkin/reference/#doc-strings); multi-line blocks that follow a step and contain long text content, which may be annotated with a media type.
+
+## Using Content
+
+The content of a doc string is appended as a plain string onto the end of a step definition function's arguments. For example:
+
+```gherkin
+Feature: Some feature
+
+  Scenario: Use multi-line doc string
+    When Fill "textarea" with:
+      """
+      This is an example of a doc string.
+
+      Doc strings can span multiple lines, and all spacing preceding each line that also precedes the block is removed.
+      """
+```
+
+Step definition:
+
+```ts
+import { createBdd } from 'playwright-bdd';
+
+const { When } = createBdd();
+
+When('Fill {string} with:', async ({ page }, selector: string, docString: string) => {
+  await page.fill(selector, docString);
+});
+```
+
+## Using Media Types
+
+A doc string may be annotated with a media type by specifying it immediately after the start of its block. Media types are exposed (if set) via the `docStringType` property of the `$step` fixture. For example:
+
+```gherkin
+Feature: Another feature
+
+  Scenario: Use JSON doc string
+    When Fill page with:
+      """json
+      {
+        "username": "vitalets",
+        "password": "12345"
+      }
+      """
+```
+
+Playwright-BDD does not parse the content of a doc string based on its media type, this behaviour is left to the step definition:
+
+```ts
+import { createBdd } from 'playwright-bdd';
+
+const { When } = createBdd();
+
+When('Fill page with:', async ({ page, $step }, docString: string) => {
+  if ($step.docStringType !== 'json') {
+    throw new Error('Doc string does not have JSON media type');
+  }
+  const data = JSON.parse(docString);
+  expect(data.username).toBe('vitalets');
+});
+```
+
+> Doc string media types are not exposed in Playwright-BDD 8.5.0 and before.

--- a/src/runtime/bddContext.ts
+++ b/src/runtime/bddContext.ts
@@ -9,6 +9,7 @@ import { BddTestData } from '../bddData/types';
 
 export type BddStepInfo = {
   title: string;
+  docStringType?: string;
 };
 
 export type BddContext = {

--- a/src/runtime/bddStepInvoker.ts
+++ b/src/runtime/bddStepInvoker.ts
@@ -33,6 +33,7 @@ export class BddStepInvoker {
   ) {
     this.bddContext.stepIndex++;
     this.bddContext.step.title = stepText;
+    this.bddContext.step.docStringType = undefined;
 
     const stepTextWithKeyword = this.getBddStepData().textWithKeyword;
     const matchedDefinition = this.findStepDefinition(stepText, stepTextWithKeyword);
@@ -122,6 +123,7 @@ export class BddStepInvoker {
       parameters.push(new DataTable(argument.dataTable));
     } else if (argument?.docString) {
       parameters.push(argument.docString.content);
+      this.bddContext.step.docStringType = argument.docString.mediaType;
     }
 
     // todo: handle invalid code length

--- a/test/bdd-syntax/features/doc-string.feature
+++ b/test/bdd-syntax/features/doc-string.feature
@@ -1,8 +1,8 @@
 Feature: doc-string
 
   Scenario: Check doc string
-    Then Passed doc string to contain "Some Title, Eh?"
-      ```
+    Then Passed doc string has media type "markdown" and contains "Some Title, Eh?"
+      ```markdown
       Some Title, Eh?
       ===
       Here is the first paragraph with different quote types '`"

--- a/test/bdd-syntax/steps-cucumber-style/fixtures.ts
+++ b/test/bdd-syntax/steps-cucumber-style/fixtures.ts
@@ -2,7 +2,7 @@ import { test as base, createBdd } from 'playwright-bdd';
 import { World } from './world';
 
 export const test = base.extend<{ world: World }>({
-  world: ({ $tags }, use, testInfo) => use({ testInfo, tags: $tags }),
+  world: ({ $tags, $step }, use, testInfo) => use({ testInfo, tags: $tags, step: $step }),
 });
 
 export const { Given, When, Then } = createBdd(test, { worldFixture: 'world' });

--- a/test/bdd-syntax/steps-cucumber-style/steps.ts
+++ b/test/bdd-syntax/steps-cucumber-style/steps.ts
@@ -38,9 +38,13 @@ Then('Custom param-no-transformer is {param-no-transformer}', function (param: s
   expect(param).toEqual('dog');
 });
 
-Then('Passed doc string to contain {string}', async function (arg: string, docString: string) {
-  expect(docString).toContain(arg);
-});
+Then(
+  'Passed doc string has media type {string} and contains {string}',
+  function (mediaType: string, content: string, docString: string) {
+    expect(this.step.docStringType).toEqual(mediaType);
+    expect(docString).toContain(content);
+  },
+);
 
 Then(
   'Passed data table to have in row {int} col {string} value {string}',

--- a/test/bdd-syntax/steps-cucumber-style/world.ts
+++ b/test/bdd-syntax/steps-cucumber-style/world.ts
@@ -1,7 +1,9 @@
 import { TestInfo } from '@playwright/test';
+import { BddStepInfo } from '../../../src/runtime/bddContext';
 
 export type World = {
   testInfo: TestInfo;
   tags: string[];
+  step: BddStepInfo;
   [key: string]: unknown;
 };

--- a/test/bdd-syntax/steps-pw-style/steps.ts
+++ b/test/bdd-syntax/steps-pw-style/steps.ts
@@ -37,9 +37,13 @@ Then('Custom param-no-transformer is {param-no-transformer}', ({}, param: string
   expect(param).toEqual('dog');
 });
 
-Then('Passed doc string to contain {string}', async ({}, arg: string, docString: string) => {
-  expect(docString).toContain(arg);
-});
+Then(
+  'Passed doc string has media type {string} and contains {string}',
+  ({ $step }, mediaType: string, content: string, docString: string) => {
+    expect($step.docStringType).toEqual(mediaType);
+    expect(docString).toContain(content);
+  },
+);
 
 Then(
   'Passed data table to have in row {int} col {string} value {string}',


### PR DESCRIPTION
Implements https://github.com/vitalets/playwright-bdd/issues/380, read issue for further context

Changes:

- ~~`tsc` errors fixed~~
  - ~~`import { parse as parseTagsExpression } from '@cucumber/tag-expressions';` is now simply `parseTagsExpression`~~
  - ~~`messages.Attachment` type extended with `& { timestamp: messages.Timestamp }`~~
  - ~~`await page.getByRole('button', { name: /hooks/ }).click();` disabled, not observed during development~~
- Expose doc string media types
  - ~~`parameters.push(argument.docString.content);` changed to push entire `argument.docString`~~
  - ~~`docString: string` and `docString` occurrences replaced with `docString: PickleDocString` and `docString.content`~~
  - `Passed doc string has media type {string} and contains {string}` step added to tests
- Documentation changes
  - ~~`[](changelog)` now points to https://github.com/vitalets/playwright-bdd/blob/main/CHANGELOG.md~~
  - Added **docs/writing-steps/doc-strings.md**
  - Added CHANGELOG entry
- ~~Repository pushing streamlined - `CRLF` does not need to be mass-converted to `LF` by Prettier~~